### PR TITLE
Remove duplicate comments

### DIFF
--- a/activities/src/bin/a16.rs
+++ b/activities/src/bin/a16.rs
@@ -8,7 +8,4 @@
 // * Use a struct containing the student's name and locker assignment
 // * The locker assignment should use an Option<i32>
 
-// * Use a struct containing the student's name and locker assignment
-// * The locker assignment should use an Option<i32>
-
 fn main() {}


### PR DESCRIPTION
Removes duplicate comments in activity 16. Comments in lines 8-9 were duplicated in lines 11-12:

https://github.com/jayson-lennon/ztm-rust/blob/b9ee05891839135ee6d17af96f9b74617e628d13/activities/src/bin/a16.rs#L8-L12